### PR TITLE
Made the page title reflect document title

### DIFF
--- a/content/tutorial/_index.md
+++ b/content/tutorial/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Hardware IO tutorials
+title: "Tutorials for using Processing on Raspberry Pi"
 date: 2018-05-14
 publishdate: 2018-05-14
 toc: false

--- a/themes/processing/layouts/tutorial/section.html
+++ b/themes/processing/layouts/tutorial/section.html
@@ -1,8 +1,10 @@
-{{ define "title" }}{{ T "archive" }} - {{ .Site.Title }}{{ end }}
+{{ define "title" }}{{.Title}} - {{ .Site.Title }}{{ end }}
 
 {{ define "content"}}
 
-<h1>Tutorials</h1>
+<h1>{{.Title}}</h1>
+
+{{ .Content }}
 
 <div class="row gutters tutorial-list">
   {{ range .Data.Pages.ByWeight }}


### PR DESCRIPTION
For https://github.com/processing/processing-pi-website/issues/27

Also made the intro paragraph / content of the page easily updateable via the content in markdown

![screen shot 2018-08-12 at 3 26 22 pm](https://user-images.githubusercontent.com/585833/44007348-658de9b6-9e48-11e8-8529-8f488a9edde6.png)
